### PR TITLE
Check if the argument is a file.

### DIFF
--- a/bin/viewprof.hs
+++ b/bin/viewprof.hs
@@ -14,6 +14,7 @@ import Data.Foldable
 import Data.Function (on)
 import Data.List.NonEmpty hiding (head, length)
 import Data.Maybe
+import System.Directory (doesFileExist)
 import System.Environment
 import System.Exit (exitFailure)
 import Text.Printf
@@ -85,9 +86,15 @@ usage = do
 parseArgs :: IO Args
 parseArgs = do
   args <- getArgs
-  if length args /= 1
-     then usage
-     else return $ Args (head args)
+  case args of
+    [arg] -> validateArgs (Args arg)
+    _ -> usage
+  where
+    validateArgs :: Args -> IO Args
+    validateArgs args = do
+      b <- doesFileExist (profilePath args)
+      unless b usage
+      pure args
 
 main :: IO ()
 main = do

--- a/viewprof.cabal
+++ b/viewprof.cabal
@@ -24,6 +24,7 @@ executable viewprof
       base >= 4.9 && < 4.11
     , brick >= 0.16 && < 0.30
     , containers >= 0.5.7 && < 0.6
+    , directory >= 1.3 && < 1.4
     , ghc-prof >= 1.4 && < 1.5
     , lens >= 4.14 && < 4.16
     , scientific >= 0.3.4.4 && < 0.4


### PR DESCRIPTION
Previously a use such as `viewprof --help` would give the ugly "could not read file" output of `openFile`. Checking if the file exists catches most these sorts of mis-uses silently and shows the user a usage.